### PR TITLE
fix: use `file.originalPath` instead of `file.path`

### DIFF
--- a/src/karma-webpack.js
+++ b/src/karma-webpack.js
@@ -243,13 +243,13 @@ Plugin.prototype.readFile = function(file, callback) {
 
 function createPreprocesor(/* config.basePath */ basePath, webpackPlugin) {
   return function(content, file, done) {
-    if (webpackPlugin.addFile(file.path)) {
+    if (webpackPlugin.addFile(file.originalPath)) {
       // recompile as we have an asset that we have not seen before
       webpackPlugin.middleware.invalidate()
     }
 
     // read blocks until bundle is done
-    webpackPlugin.readFile(path.relative(basePath, file.path), function(err, content) {
+    webpackPlugin.readFile(path.relative(basePath, file.originalPath), function(err, content) {
       if (err) {
         throw err
       }


### PR DESCRIPTION
Because other plugins (such as https://github.com/gjurgens/karma-renamer-preprocessor) may change the path.

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
If this plugin is used with https://github.com/gjurgens/karma-renamer-preprocessor and `singleRun` is `false`, it fails on subsequent builds as it is looking at the renamed path, not the original one.

**What is the new behavior?**
If another plugin changes the path it won't effect how this works.

**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No
