### PR TITLE
actually fixed readFile (windows)

### DIFF
--- a/src/karma-webpack.js
+++ b/src/karma-webpack.js
@@ -183,7 +183,7 @@ Plugin.prototype.readFile = function(file, callback) {
   var middleware = this.middleware
   var optionsCount = this.optionsCount
 
-  function doRead() {
+  var doRead = function() {
     if (optionsCount > 1) {
       async.times(optionsCount, function(idx, callback) {
         middleware.fileSystem.readFile('/_karma_webpack_/' + idx + '/' + file.replace(/\\/g, '/'), callback)
@@ -202,20 +202,27 @@ Plugin.prototype.readFile = function(file, callback) {
         callback(null, Buffer.concat(contents))
       })
     } else {
-      middleware.fileSystem.readFile('/_karma_webpack_/' + file.replace(/\\/g, '/'), callback)
-    }
-  }
-  if (!this.waiting) {
-    try {
-      doRead()
-    } catch (e) {
-      // If this is an error from `readFileSync` method, wait for the next tick. Credit #69 @mewdriller
-      if (e.message.substring(0, 20) === "Path doesn't exist '") { // eslint-disable-line quotes
-        this.waiting = [process.nextTick.bind(process, this.readFile.bind(this, file, callback))]
-      } else {
-        throw e
+      try {
+        var fileContents = middleware.fileSystem.readFileSync('/_karma_webpack_/' + file.replace(/\\/g, '/'))
+
+        callback(undefined, fileContents)
+      } catch (e) {
+        // If this is an error from `readFileSync` method, wait for the next tick.
+        // Credit #69 @mewdriller
+        if (e.code === 'ENOENT') {
+          // eslint-disable-line quotes
+          this.waiting = [process.nextTick.bind(process, this.readFile.bind(this, file, callback))]
+
+          // throw otherwise
+        } else {
+          callback(e)
+        }
       }
     }
+  }.bind(this)
+
+  if (!this.waiting) {
+    doRead()
   } else {
     // Retry to read once a build is finished
     // do it on process.nextTick to catch changes while building

--- a/src/karma-webpack.js
+++ b/src/karma-webpack.js
@@ -16,7 +16,8 @@ function Plugin(
 	/* config.files */ files,
 	/* config.frameworks */ frameworks,
 	customFileHandlers,
-	emitter) {
+	emitter
+) {
   webpackOptions = _.clone(webpackOptions) || {}
   webpackMiddlewareOptions = _.clone(webpackMiddlewareOptions || webpackServerOptions) || {}
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [x] Bugfix
- [x] Refactoring (no functional changes, no api changes)

**What is the current behavior?** (You can also link to an open issue here)
The fix in https://github.com/webpack-contrib/karma-webpack/pull/208 (#69, #40) didn't work. When creating new files that match the globbing pattern in karma.config, the watcher crashes and needs a manual restart. 

**What is the new behavior?**
Watcher doesn't crash when creating new files :)

**Does this PR introduce a breaking change?**
- [x] No

**Other information**:
Tried to wrap my head around the contributing guide, but ran into problems. If you need me to update anything please let me know.