### PR TITLE
fix: work with source maps when wrapped (`mocha-env-loader`)

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "async": "~0.9.0",
     "loader-utils": "^0.2.5",
     "lodash": "^3.8.0",
-    "source-map": "^0.1.41",
+    "source-map": "^0.5.6",
     "webpack-dev-middleware": "^1.0.11"
   },
   "devDependencies": {

--- a/src/mocha-env-loader.js
+++ b/src/mocha-env-loader.js
@@ -1,6 +1,8 @@
-//var path = require('path')
-var SourceNode = require('source-map').SourceNode
+var sourceMap = require('source-map')
 var loaderUtils = require('loader-utils')
+
+var SourceNode = sourceMap.SourceNode
+var SourceMapConsumer = sourceMap.SourceMapConsumer
 
 module.exports = function(content, map) {
   this.cacheable()
@@ -9,11 +11,11 @@ module.exports = function(content, map) {
   var id = this.options.name
 
   if (!id) {
-    this.callback(null, content, map)
+    return this.callback(null, content, map)
   }
 
   if (map) {
-    sourceNode = SourceNode.fromSourceWithMap(content, map)
+    sourceNode = SourceNode.fromStringWithSourceMap(content, new SourceMapConsumer(map))
   } else {
     var fileName = loaderUtils.getRemainingRequest(this)
 


### PR DESCRIPTION
### Notable Changes

When mocha is wrapped and a sourcemap is present, the `mocha-env-loader` [tries to call `SourceNode.fromSourceWithMap(content, map)`](https://github.com/webpack-contrib/karma-webpack/blob/4701b62d9e99caeb8497144743f9ec010538cf77/src/mocha-env-loader.js#L16).

The `SourceNode.fromSourceWithMap()` function isn't defined [in `source-map@0.1.41`](https://github.com/mozilla/source-map/blob/0.1.41/lib/source-map/source-node.js) (I'm not sure if it was ever part of that library).

I've updated the dependency to `source-map@0.5.6` and adapted the code to the new API.

This gets rid of the `TypeError: SourceNode.fromSourceWithMap is not a function` from the log and reveals `Error: callback(): The callback was already called.` instead.  Assuming the intention was to return after calling the callback, I added a return.

### Code

See https://gist.github.com/tschaub/b7700159dad789c4a0b91f2038dd0f58 for steps to reproduce.

### Issues

- Fixes #237

> ℹ️  edited by @michael-ciniawsky (Formatting)