### PR TITLE
fix: disable `webpack` rebuilds on karma `--single-run`

### DIFF
--- a/src/karma-webpack.js
+++ b/src/karma-webpack.js
@@ -16,6 +16,7 @@ function Plugin(
 	/* config.basePath */ basePath,
 	/* config.files */ files,
 	/* config.frameworks */ frameworks,
+	/* config.singleRun */ singleRun,
 	customFileHandlers,
 	emitter
 ) {
@@ -27,7 +28,7 @@ function Plugin(
 
   applyOptions.forEach(function(webpackOptions, index) {
     // The webpack tier owns the watch behavior so we want to force it in the config
-    webpackOptions.watch = true
+    webpackOptions.watch = !singleRun
 
     // Webpack 2.1.0-beta.7+ will throw in error if both entry and plugins are not specified in options
     // https://github.com/webpack/webpack/commit/b3bc5427969e15fd3663d9a1c57dbd1eb2c94805

--- a/test/unit/plugin.test.js
+++ b/test/unit/plugin.test.js
@@ -12,7 +12,7 @@ describe('Plugin', function() {
           cb(new Error('test error'))
         }
       }
-      var Plugin = new webpackPlugin[1]({}, {}, {}, '', [], [], [], emitterMock)
+      var Plugin = new webpackPlugin[1]({}, {}, {}, '', [], [], true, [], emitterMock)
 
       Plugin.addFile('test.js')
       Plugin.make(compilationMock, function(err) {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
When running a long test suite as a single run, if you make changes to any of the files during the run, webpack will start recompiling


**What is the new behavior?**
Webpack is only run in watch mode when running karma is not running with the `--single-run` flag


**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the following...

N/A


**Other information**:

