### PR TITLE
fix(karma-webpack): ensure webpack `output` paths include a trailing slash

### DIFF
--- a/src/karma-webpack.js
+++ b/src/karma-webpack.js
@@ -48,8 +48,8 @@ function Plugin(
 
     // Must have the common _karma_webpack_ prefix on path here to avoid
     // https://github.com/webpack/webpack/issues/645
-    webpackOptions.output.path = path.join(os.tmpdir(), '_karma_webpack_', indexPath)
-    webpackOptions.output.publicPath = path.join(os.tmpdir(), '_karma_webpack_', publicPath)
+    webpackOptions.output.path = path.join(os.tmpdir(), '_karma_webpack_', indexPath, '/')
+    webpackOptions.output.publicPath = path.join(os.tmpdir(), '_karma_webpack_', publicPath, '/')
     webpackOptions.output.filename = '[name]'
     if (includeIndex) {
       webpackOptions.output.jsonpFunction = 'webpackJsonp' + index
@@ -133,7 +133,7 @@ function Plugin(
     }
   }.bind(this))
 
-  webpackMiddlewareOptions.publicPath = path.join(os.tmpdir(), '_karma_webpack_')
+  webpackMiddlewareOptions.publicPath = path.join(os.tmpdir(), '_karma_webpack_', '/')
   var middleware = this.middleware = new webpackDevMiddleware(compiler, webpackMiddlewareOptions)
 
   customFileHandlers.push({


### PR DESCRIPTION
Prior to #279, the following paths would always end with a slash:
- `webpackOptions.output.publicPath`
- `webpackOptions.output.publicPath`
- `webpackMiddlewareOptions.publicPath`

Fixes #284

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

`webpackOptions.output.publicPath`, `webpackOptions.output.publicPath` and `webpackMiddlewareOptions.publicPath` do not always include a trailing slash, as they did prior to #279.

**What is the new behavior?**

`webpackOptions.output.publicPath`, `webpackOptions.output.publicPath` and `webpackMiddlewareOptions.publicPath` will always include a trailing slash.

**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No (but it does attempt to fix one!)

If this PR contains a breaking change, please describe the following...

* Impact:
* Migration path for existing applications:
* Github Issue(s) this is regarding:


**Other information**:

