### PR TITLE
fix(karma-webpack): correctly coalesce `idx` (`{Number}`) in filepaths

### DIFF
--- a/src/karma-webpack.js
+++ b/src/karma-webpack.js
@@ -198,7 +198,7 @@ Plugin.prototype.readFile = function(file, callback) {
   var doRead = function() {
     if (optionsCount > 1) {
       async.times(optionsCount, function(idx, callback) {
-        middleware.fileSystem.readFile(path.join(os.tmpdir(), '_karma_webpack_', idx.toString(), file.replace(/\\/g, '/')), callback)
+        middleware.fileSystem.readFile(path.join(os.tmpdir(), '_karma_webpack_', String(idx), file.replace(/\\/g, '/')), callback)
       }, function(err, contents) {
         if (err) {
           return callback(err)

--- a/src/karma-webpack.js
+++ b/src/karma-webpack.js
@@ -198,7 +198,7 @@ Plugin.prototype.readFile = function(file, callback) {
   var doRead = function() {
     if (optionsCount > 1) {
       async.times(optionsCount, function(idx, callback) {
-        middleware.fileSystem.readFile(path.join(os.tmpdir(), '_karma_webpack_', idx, file.replace(/\\/g, '/')), callback)
+        middleware.fileSystem.readFile(path.join(os.tmpdir(), '_karma_webpack_', idx.toString(), file.replace(/\\/g, '/')), callback)
       }, function(err, contents) {
         if (err) {
           return callback(err)


### PR DESCRIPTION
fix: convert index to string before passing to path.join to avoid TypeError

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
#286 


**What is the new behavior?**
Converts an index to a string before it gets passed into path.join. It was previously being coalesced before 0616dda489d07f6a9bc3def1778dcef601411821


**Does this PR introduce a breaking change?**
- [ ] Yes
- [X] No

If this PR contains a breaking change, please describe the following...

* Impact:
* Migration path for existing applications:
* Github Issue(s) this is regarding:


**Other information**:

