### PR TITLE
fix: fix "urlRegex" in custom file handler

### DIFF
--- a/src/karma-webpack.js
+++ b/src/karma-webpack.js
@@ -9,6 +9,11 @@ var SingleEntryDependency = require('webpack/lib/dependencies/SingleEntryDepende
 var blocked = []
 var isBlocked = false
 
+var escapeForRegExp = function(str) {
+  // See details here https://stackoverflow.com/questions/3446170/escape-string-for-use-in-javascript-regex
+  return str.replace(/[-[\]/{}()*+?.\\^$|]/g, '\\$&')
+}
+
 function Plugin(
 	/* config.webpack */ webpackOptions,
 	/* config.webpackServer */ webpackServerOptions,
@@ -138,7 +143,7 @@ function Plugin(
   var middleware = this.middleware = new webpackDevMiddleware(compiler, webpackMiddlewareOptions)
 
   customFileHandlers.push({
-    urlRegex: new RegExp('^' + os.tmpdir() + '\/_karma_webpack_\/.*/'),
+    urlRegex: new RegExp('^' + escapeForRegExp(webpackMiddlewareOptions.publicPath) + '.*'),
     handler: function(req, res) {
       middleware(req, res, function() {
         res.statusCode = 404


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

`customFileHanlder` does not handle any files due to bug in `urlRegex` regular expression
In my case it broke test where i use **file-loader** plugin 

I guess here is the same issue #291 

**What is the new behavior?**

Fixed regular expression for `customFileHandle`:
- removed unneeded escape symbols
- added function to escape `publicPath` string. NOTE: this function is not needed when running on linux based OS-es due to `os.tmpdir()` does not contain special characters, but should help in edge cases(Windows, ???)

short example to explain issue:
```javascript
    // in my case below url was generated by file-loader
    const url = '/tmp/_karma_webpack_/8f503faad8b590c8a6075b27426dc9c0.json';
    // os.tmpdir() -> "/tmp" in my case(Ubuntu) 
    const originalRe = new RegExp('^/tmp\/_karma_webpack_\/.*/');
    console.log('original urlRegex:', originalRe.test(url));  // false

    const fixedRe = new RegExp('^/tmp/_karma_webpack_/.*');
    console.log('fixed urlRegex:', fixedRe.test(url));  // true

```

**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the following...

* Impact:
* Migration path for existing applications:
* Github Issue(s) this is regarding:

**Other information**:

