### PR TITLE
fix: wrong regex in middleware url pattern

### DIFF
--- a/src/karma-webpack.js
+++ b/src/karma-webpack.js
@@ -138,7 +138,7 @@ function Plugin(
   var middleware = this.middleware = new webpackDevMiddleware(compiler, webpackMiddlewareOptions)
 
   customFileHandlers.push({
-    urlRegex: new RegExp('^' + os.tmpdir() + '\/_karma_webpack_\/.*/'),
+    urlRegex: new RegExp('^' + os.tmpdir() + '\/_karma_webpack_\/.*$'),
     handler: function(req, res) {
       middleware(req, res, function() {
         res.statusCode = 404


### PR DESCRIPTION
I upgraded `karma-webpack` to the latest version. It seems that assets emitted directly to the webpack’s `output.path` directory (not in a subdirectory) couldn’t be found.

Debugging this issue reveals that the regex used to tell karma to delegate to webpack-dev-server is incorrect. It has an extra `/` at the end. I assume that the author intended to say `$` instead, since there is already a `/` in front, (otherwise, there is no point in having `.*`).

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
http://localhost:9876/tmp/_karma_webpack_/24476c7dae9a65fd37e5.worker.js returns 404.

**What is the new behavior?**
http://localhost:9876/tmp/_karma_webpack_/24476c7dae9a65fd37e5.worker.js now returns the emitted file as intended.


**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No


**Other information**:

**Workaround:** Just make sure you setup loaders (e.g. file-loader, worker-loader) to emit files inside a directory instead.