### PR TITLE
fix(package): use `babel-runtime` is a `dependency` (`dependencies`)

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "dependencies": {
     "async": "^2.0.0",
+    "babel-runtime": "^6.0.0",
     "loader-utils": "^1.0.0",
     "lodash": "^4.0.0",
     "source-map": "^0.5.6",
@@ -41,7 +42,6 @@
     "babel-polyfill": "^6.0.0",
     "babel-preset-env": "^1.0.0",
     "babel-register": "^6.0.0",
-    "babel-runtime": "^6.0.0",
     "chai": "^4.0.0",
     "chai-as-promised": "^7.0.0",
     "cross-env": "^5.0.0",


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [*] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

`lib/karma-webpack.js` has the following line:

```js
var _toConsumableArray2 = require('babel-runtime/helpers/toConsumableArray');
```

When using `pnpm`, the babel-runtime is marked as a devDependency and therefore not included in the `node_modules`. Hence you get the following error:

```
27 02 2018 10:54:19.765:ERROR [config]: Invalid config file!
  Error: Cannot find module 'babel-runtime/helpers/toConsumableArray'
    at Function.Module._resolveFilename (module.js:469:15)
    at Function.Module._load (module.js:417:25)
    at Module.require (module.js:497:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (D:\GitRepos\sp-client2\common\temp\node_modules\.onedrive.pkgs.visualstudio.com\karma-webpack\2.0.12\webpack@3.6.0\node_modules\karma-webpack\lib\karma-webpack.js:3:27)
```

**What is the new behavior?**

The `babel-runtime` is installed as a runtime dependency.

**Does this PR introduce a breaking change?**
- [ ] Yes
- [*] No

If this PR contains a breaking change, please describe the following...

* Impact:
* Migration path for existing applications:
* Github Issue(s) this is regarding:


**Other information**:

