### PR TITLE
chore(package): update `webpack-dev-middleware` v1.12.0...2.0.6 (`dependencies`)

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "release": "standard-version"
   },
   "peerDependencies": {
-    "webpack": "^1.0.0 || ^2.0.0 || ^3.0.0 || ^4.0.0"
+    "webpack": "^2.2.0 || ^3.0.0 || ^4.0.0"
   },
   "dependencies": {
     "async": "^2.0.0",
@@ -33,7 +33,7 @@
     "loader-utils": "^1.0.0",
     "lodash": "^4.0.0",
     "source-map": "^0.5.6",
-    "webpack-dev-middleware": "^1.12.0"
+    "webpack-dev-middleware": "^2.0.6"
   },
   "devDependencies": {
     "babel-cli": "^6.0.0",


### PR DESCRIPTION
Fixes #314 

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe:
  - Update `webpack-dev-middleware` dependency

**Does this PR introduce a breaking change?**
- [x] Yes
- [ ] No

If this PR contains a breaking change, please describe the following...

* Impact: the new major release is required since `webpack ^1.0.0` support has been dropped in `webpack-dev-middleware ^2.0.0`


**Other information**:

- https://github.com/webpack/webpack-dev-middleware/releases/tag/v2.0.0