### PR TITLE
fix(karma-webpack): disable `optimization` by default (`webpack >= v4.0.0`)

### DIFF
--- a/src/karma-webpack.js
+++ b/src/karma-webpack.js
@@ -67,6 +67,13 @@ function Plugin(
       webpackOptions.output.jsonpFunction = `webpackJsonp${index}`
     }
     webpackOptions.output.chunkFilename = '[id].bundle.js'
+
+    // For webpack 4+, optimization.splitChunks and optimization.runtimeChunk must be false.
+    // Otherwise it hangs at 'Compiled successfully'
+    if (webpackOptions.optimization) {
+      webpackOptions.optimization.splitChunks = false
+      webpackOptions.optimization.runtimeChunk = false
+    }
   })
 
   this.emitter = emitter


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)

For webpack 4, the presence of `optimization.splitChunks` and `optimization.runtimeChunk` causes karma to hang at the message 'Compiled successfully' (#322)

**What is the new behavior?**

A workaround is for end-users to set these two properties to `false` in their webpack/karma configs; however it would make more sense to have `karma-webpack` do this in all cases, so that new users aren't left scratching their heads as to why their test suite won't run. 

### `Type`

- [x] Bugfix

### `Issues`

- Fixes #322

### `SemVer`

 - Fix (🏷 Patch)

### `Checklist`

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
