### PR TITLE
feat(karma-webpack): pass-through provided webpack config.stats

### DIFF
--- a/src/karma-webpack.js
+++ b/src/karma-webpack.js
@@ -112,8 +112,8 @@ function Plugin(
     var assets = []
     var noAssets = false
 
-    applyStats.forEach(function(stats) {
-      stats = stats.toJson()
+    applyStats.forEach(function(stats, index) {
+      stats = stats.toJson(applyOptions[index].stats)
 
       assets.push(...stats.assets)
       if (stats.assets.length === 0) {


### PR DESCRIPTION
When stats configuration is provided on the webpack config, use it when calling stats.toJson().
This allows users to customize what is displayed to command line each time webpack is run.

This resolves #328

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [ *] Feature

**What is the current behavior?** (You can also link to an open issue here)
#328 


**What is the new behavior?**
Stats configuration is passed through, so webpack command line output is modified accordingly


**Does this PR introduce a breaking change?**
- [ ] Yes
- [* ] No

