### PR TITLE
fix(karma-webpack): allow `filename` and `chunkFilename` to be overridden (`config.output`)

### DIFF
--- a/src/karma-webpack.js
+++ b/src/karma-webpack.js
@@ -62,11 +62,15 @@ function Plugin(
     // https://github.com/webpack/webpack/issues/645
     webpackOptions.output.path = path.join(os.tmpdir(), '_karma_webpack_', indexPath, '/')
     webpackOptions.output.publicPath = path.join(os.tmpdir(), '_karma_webpack_', publicPath, '/')
-    webpackOptions.output.filename = '[name]'
     if (includeIndex) {
       webpackOptions.output.jsonpFunction = `webpackJsonp${index}`
     }
-    webpackOptions.output.chunkFilename = '[id].bundle.js'
+    if (!webpackOptions.output.filename) {
+      webpackOptions.output.filename = '[name].js'
+    }
+    if (!webpackOptions.output.chunkFilename) {
+      webpackOptions.output.chunkFilename = '[id].bundle.js'
+    }
   })
 
   this.emitter = emitter


### PR DESCRIPTION
### `Type`

- [x] Bugfix

### `Issues`

- Fixes #334

### `SemVer`

 - Fix (🏷 Patch)

### `Checklist`

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

