### PR TITLE
fix(karma-webpack): don't include `os.tmpdir` (`options.publicPath`)

### DIFF
--- a/src/karma-webpack.js
+++ b/src/karma-webpack.js
@@ -79,7 +79,7 @@ function Plugin(
       '/'
     );
     webpackOptions.output.publicPath = path.join(
-      os.tmpdir(),
+      '/',
       '_karma_webpack_',
       publicPath,
       '/'
@@ -209,7 +209,7 @@ function Plugin(
   compiler.hooks.invalid.tap(this.plugin, invalid.bind(this));
 
   webpackMiddlewareOptions.publicPath = path.join(
-    os.tmpdir(),
+    '/',
     '_karma_webpack_',
     '/'
   );


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

This fixes issue #333 where a worker would fail to load due to a CORS issue. This change does NOT affect the write path for the webpack build, but the public path reflected in something like `<base href="/_karma_webpack/">`. 

**What is the new behavior?**

The `os.tmpdir()` is stripped from the webpack's publicPath so that async assets are loaded correctly from a common domain avoiding CORS issues.

**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the following...

* Impact:
* Migration path for existing applications:
* Github Issue(s) this is regarding:


**Other information**: