### PR TITLE
fix(karma-webpack): `compilation` hangs when adding a file

### DIFF
--- a/src/karma-webpack.js
+++ b/src/karma-webpack.js
@@ -221,9 +221,12 @@ Plugin.prototype.notifyKarmaAboutChanges = function() {
 
 Plugin.prototype.addFile = function(entry) {
   if (this.files.indexOf(entry) >= 0) {
-    return;
+    return false;
   }
+
   this.files.push(entry);
+
+  return true;
 };
 
 Plugin.prototype.make = function(compilation, callback) {


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?**

During the refactoring, the method to add a file no longer returned `true`, causing the whole process to stall and karma not to start.

I'll add some integration tests ASAP.

**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No