### PR TITLE
fix(karma-webpack): don't include the file extension (`output.filename`)

### DIFF
--- a/src/karma-webpack.js
+++ b/src/karma-webpack.js
@@ -90,11 +90,11 @@ function Plugin(
     }
 
     if (!webpackOptions.output.filename) {
-      webpackOptions.output.filename = '[name].js'
+      webpackOptions.output.filename = '[name]';
     }
 
     if (!webpackOptions.output.chunkFilename) {
-      webpackOptions.output.chunkFilename = '[id].bundle.js'
+      webpackOptions.output.chunkFilename = '[id].bundle.js';
     }
 
     // For webpack 4+, optimization.splitChunks and optimization.runtimeChunk must be false.


### PR DESCRIPTION
This PR contains a bug fix

https://github.com/webpack-contrib/karma-webpack/issues/322

