### PR TITLE
fix(karma-webpack): normalize paths (`windows`)

### DIFF
--- a/src/karma-webpack.js
+++ b/src/karma-webpack.js
@@ -308,7 +308,7 @@ Plugin.prototype.readFile = function(file, callback) {
               os.tmpdir(),
               '_karma_webpack_',
               String(idx),
-              this.outputs.get(file)
+              this.outputs.get(file.replace(/\\/g, '/'))
             ),
             callback
           );
@@ -334,7 +334,11 @@ Plugin.prototype.readFile = function(file, callback) {
     } else {
       try {
         const fileContents = middleware.fileSystem.readFileSync(
-          path.join(os.tmpdir(), '_karma_webpack_', this.outputs.get(file))
+          path.join(
+            os.tmpdir(),
+            '_karma_webpack_',
+            this.outputs.get(file.replace(/\\/g, '/'))
+          )
         );
 
         callback(null, fileContents);
@@ -382,9 +386,6 @@ function createPreprocesor(/* config.basePath */ basePath, webpackPlugin) {
       if (err) {
         throw err;
       }
-
-      const outputPath = webpackPlugin.outputs.get(filename);
-      file.path = path.join(basePath, outputPath);
 
       done(err, content && content.toString());
     });


### PR DESCRIPTION
With #347 changes, now get error: `TypeError: Path must be a string. Received undefined`. After my research, there are 3 places will throw this error:

1. Two in the `readFile`, [L311](https://github.com/webpack-contrib/karma-webpack/blob/master/src/karma-webpack.js#L311), [L337](https://github.com/webpack-contrib/karma-webpack/blob/master/src/karma-webpack.js#L337), both are `this.outputs.get(file)`
--- the changes I made here is to map the file path to the entry path, so that can getting the file from the outputs. Example, changes from `test\unit\karma-test-shim` to `test/unit/karma-test-shim`

2. One in the `createPreprocesor` [L386](https://github.com/webpack-contrib/karma-webpack/blob/master/src/karma-webpack.js#L386), this line `webpackPlugin.outputs.get(filename);`
--- for this one, the file is already the real file path, if replaced with the webpack stats one, the karma web server cannot find the file 404.
Example here, changes from `C:/project/test/unit/karma-test-shim.js` to `C:\project\test\unit\karma-test-shim.js`

### Type

- [x] Fix

### Issues

- Fixes #350 

### SemVer

- [x] Patch