### PR TITLE
:bug: fix output assets path undefined

### DIFF
--- a/src/karma-webpack.js
+++ b/src/karma-webpack.js
@@ -235,7 +235,7 @@ Plugin.prototype.readFile = function(file, callback) {
   var doRead = function() {
     if (optionsCount > 1) {
       async.times(optionsCount, function(idx, callback) {
-        middleware.fileSystem.readFile(path.join(os.tmpdir(), '_karma_webpack_', String(idx), this.outputs[file]), callback)
+        middleware.fileSystem.readFile(path.join(os.tmpdir(), '_karma_webpack_', String(idx), this.outputs[file.replace(/\\/g, "/")]), callback)
       }.bind(this), function(err, contents) {
         if (err) {
           return callback(err)
@@ -252,7 +252,7 @@ Plugin.prototype.readFile = function(file, callback) {
       })
     } else {
       try {
-        var fileContents = middleware.fileSystem.readFileSync(path.join(os.tmpdir(), '_karma_webpack_', this.outputs[file]))
+        var fileContents = middleware.fileSystem.readFileSync(path.join(os.tmpdir(), '_karma_webpack_', this.outputs[file.replace(/\\/g, "/")]))
 
         callback(undefined, fileContents)
       } catch (e) {
@@ -294,7 +294,7 @@ function createPreprocesor(/* config.basePath */ basePath, webpackPlugin) {
         throw err
       }
 
-      var outputPath = webpackPlugin.outputs[filename]
+      var outputPath = webpackPlugin.outputs[filename.replace(/\\/g, "/")]
       file.path = path.join(basePath, outputPath)
 
       done(err, content && content.toString())


### PR DESCRIPTION
This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

This error show on windows OS:

04 09 2018 16:02:38.163:ERROR [karma]: TypeError: Path must be a string. Received undefined
  at assertPath (path.js:28:11)
  at Object.join (path.js:499:7)
  at Plugin.<anonymous> (..\node_modules\karma-webpack\lib\karma-webpack.js:262:68)
  at Plugin.readFile (..\node_modules\karma-webpack\lib\karma-webpack.js:281:5)
  at _combinedTickCallback (internal/process/next_tick.js:131:7)
  at process._tickCallback (internal/process/next_tick.js:180:9)

04 09 2018 16:02:38.178:ERROR [karma]: TypeError: Path must be a string. Received undefined
  at assertPath (path.js:28:11)
  at Object.join (path.js:499:7)
  at Plugin.<anonymous> (..\node_modules\karma-webpack\lib\karma-webpack.js:262:68)
  at Plugin.readFile (..\node_modules\karma-webpack\lib\karma-webpack.js:281:5)
  at _combinedTickCallback (internal/process/next_tick.js:131:7)
  at Immediate._tickCallback [as _onImmediate] (internal/process/next_tick.js:180:9)
  at runCallback (timers.js:789:20)
  at tryOnImmediate (timers.js:751:5)
  at processImmediate [as _immediateCallback] (timers.js:722:5)

The output assets array has indexes like 'path/to/file' and the file name is 'path\to\file'

### Breaking Changes

### Additional Info