### PR TITLE
feat(karma-webpack): unify `webpack` and  `karma` color config

### DIFF
--- a/src/karma-webpack.js
+++ b/src/karma-webpack.js
@@ -39,6 +39,7 @@ function Plugin(
   /* config.files */ files,
   /* config.frameworks */ frameworks,
   /* config.singleRun */ singleRun,
+  /* config.colors */ colors,
   customFileHandlers,
   emitter
 ) {
@@ -210,11 +211,12 @@ function Plugin(
   compiler.hooks.done.tap(this.plugin, done.bind(this));
   compiler.hooks.invalid.tap(this.plugin, invalid.bind(this));
 
-  webpackMiddlewareOptions.publicPath = path.join(
-    '/',
-    '_karma_webpack_',
-    '/'
-  );
+  webpackMiddlewareOptions.publicPath = path.join('/', '_karma_webpack_', '/');
+
+  // Set webpack's color config to value specified in Karma's config for consistency
+  webpackMiddlewareOptions.stats = webpackMiddlewareOptions.stats || {};
+  webpackMiddlewareOptions.stats.colors = colors;
+
   const middleware = new WebpackDevMiddleware(
     compiler,
     webpackMiddlewareOptions

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -19,6 +19,7 @@ describe('Plugin', () => {
         [],
         [],
         true,
+        true,
         [],
         emitterMock
       );


### PR DESCRIPTION
Unifies the color config between webpack and Karma. See https://github.com/webpack-contrib/karma-webpack/issues/332

### Type

- [x] Feature

### Issues

- Fixes #332 

### SemVer

- [x] Minor