### PR TITLE
:bug: fix TypeError: Path must be a string. Received Array

### DIFF
--- a/src/karma-webpack.js
+++ b/src/karma-webpack.js
@@ -237,7 +237,11 @@ Plugin.prototype.readFile = function(file, callback) {
   var doRead = function() {
     if (optionsCount > 1) {
       async.times(optionsCount, function(idx, callback) {
-        middleware.fileSystem.readFile(path.join(os.tmpdir(), '_karma_webpack_', String(idx), this.outputs[file]), callback)
+        if (Array.isArray(this.outputs[file])) {
+          middleware.fileSystem.readFile(path.join(os.tmpdir(), '_karma_webpack_', String(idx), this.outputs[file][0]), callback);
+        }else{
+          middleware.fileSystem.readFile(path.join(os.tmpdir(), '_karma_webpack_', String(idx), this.outputs[file]), callback);
+        }
       }.bind(this), function(err, contents) {
         if (err) {
           return callback(err)
@@ -254,7 +258,11 @@ Plugin.prototype.readFile = function(file, callback) {
       })
     } else {
       try {
-        var fileContents = middleware.fileSystem.readFileSync(path.join(os.tmpdir(), '_karma_webpack_', this.outputs[file]))
+        if (Array.isArray(this.outputs[file])) {
+          var fileContents = middleware.fileSystem.readFileSync(path.join(os.tmpdir(), '_karma_webpack_', this.outputs[file][0]));
+        } else {
+          var fileContents = middleware.fileSystem.readFileSync(path.join(os.tmpdir(), '_karma_webpack_', this.outputs[file]));
+        }
 
         callback(undefined, fileContents)
       } catch (e) {
@@ -297,7 +305,11 @@ function createPreprocesor(/* config.basePath */ basePath, webpackPlugin) {
       }
 
       var outputPath = webpackPlugin.outputs[normalize(filename)]
-      file.path = normalize(path.join(basePath, outputPath))
+      if( Array.isArray(outputPath)){
+        file.path = normalize(path.join(basePath, outputPath[0]));
+      } else {
+        file.path = normalize(path.join(basePath, outputPath));
+      }
 
       done(err, content && content.toString())
     })


### PR DESCRIPTION
This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

When configuring Webpack to compile ts, the output is array and karma-webpack throw Exception like 

08 09 2018 02:13:38.035:ERROR [karma]: TypeError: Path must be a string. Received [ 'spec/vendors.spec.js', 'spec/app.spec.js.map' ]
    at assertPath (path.js:28:11)
    at Object.join (path.js:1236:7)
    at Plugin.<anonymous> (../node_modules/karma-webpack/lib/karma-webpack.js:286:70)
    at Plugin.readFile (../node_modules/karma-webpack/lib/karma-webpack.js:305:5)
    at _combinedTickCallback (internal/process/next_tick.js:131:7)
    at process._tickCallback (internal/process/next_tick.js:180:9)

