### PR TITLE
fix(npm packaging): restore prepare script in package.json so that npm install from github works

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "lint-staged": "lint-staged",
     "prebuild": "npm run clean",
     "prepublish": "npm run build",
+    "prepare": "npm run build",
     "release": "standard-version",
     "release:ci": "conventional-github-releaser -p angular",
     "release:validate": "commitlint --from=$(git describe --tags --abbrev=0) --to=$(git rev-parse HEAD)",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "ci:lint:commits": "commitlint --from=${CIRCLE_BRANCH} --to=${CIRCLE_SHA1}",
     "lint-staged": "lint-staged",
     "prebuild": "npm run clean",
-    "prepublish": "npm run build",
     "prepare": "npm run build",
     "release": "standard-version",
     "release:ci": "conventional-github-releaser -p angular",


### PR DESCRIPTION
Date:   Fri Oct 19 16:08:37 2018 +0100

    fix(npm packaging): restore prepare script in package.json so that npm install from github works

    In commit 2a4d3b the prepare script was removed from package.json.  After that, it is no longer
    possible to specify a github location in the project's package.json file to load a specific version
    of the package from Github.  It should be possible to load the package using a command such as npm
    install github:webpack-contrib/karma-webpack

<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

### Additional Info