### PR TITLE
fix(karma-webpack): Fix publicPath to be Windows-compatible

### DIFF
--- a/src/karma-webpack.js
+++ b/src/karma-webpack.js
@@ -95,10 +95,7 @@ function Plugin(
       indexPath,
       '/'
     );
-    webpackOptions.output.publicPath = 
-      '/_karma_webpack_' +
-      publicPath +
-      '/';
+    webpackOptions.output.publicPath = `/_karma_webpack_${publicPath}/`;
 
     if (includeIndex) {
       webpackOptions.output.jsonpFunction = `webpackJsonp${index}`;

--- a/src/karma-webpack.js
+++ b/src/karma-webpack.js
@@ -95,12 +95,10 @@ function Plugin(
       indexPath,
       '/'
     );
-    webpackOptions.output.publicPath = path.join(
-      '/',
-      '_karma_webpack_',
-      publicPath,
-      '/'
-    );
+    webpackOptions.output.publicPath = 
+      '/_karma_webpack_' +
+      publicPath +
+      '/';
 
     if (includeIndex) {
       webpackOptions.output.jsonpFunction = `webpackJsonp${index}`;

--- a/src/karma-webpack.js
+++ b/src/karma-webpack.js
@@ -225,7 +225,7 @@ function Plugin(
   compiler.hooks.done.tap(this.plugin, done.bind(this));
   compiler.hooks.invalid.tap(this.plugin, invalid.bind(this));
 
-  webpackMiddlewareOptions.publicPath = path.join('/', '_karma_webpack_', '/');
+  webpackMiddlewareOptions.publicPath = '/_karma_webpack_/';
   const middleware = new WebpackDevMiddleware(
     compiler,
     webpackMiddlewareOptions


### PR DESCRIPTION
This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

Taking over #366 (cleaned up PR and fixed another instance of `publicPath`). Fixes #362 (tested using steps provided by @johnnyreilly).

Public path is a URL, not a file path. It should not be created using `path.join`, which uses backslashes on Windows.
