### PR TITLE
fix(karma-webpack): Override output.filename if it is a static file name

### DIFF
--- a/src/karma-webpack.js
+++ b/src/karma-webpack.js
@@ -102,7 +102,9 @@ function Plugin(
       webpackOptions.output.jsonpFunction = `webpackJsonp${index}`;
     }
 
-    if (!webpackOptions.output.filename) {
+    // If filename doesn't contain [name], it is static and needs to be overridden,
+    // since we have multiple entry points
+    if (!webpackOptions.output.filename || !webpackOptions.output.filename.includes('[name]')) {
       webpackOptions.output.filename = '[name].js';
     }
 


### PR DESCRIPTION
This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

If there are multiple tests, and the webpack configuration has a static `output.filename`, e.g. `'bundle.js'`, all entry points will be emitted to the same bundle. Karma will output errors, and `karma-webpack` will ultimately fail as test files will not have any corresponding output file.
