### PR TITLE
fix: add dynamic imports to main bundle

### DIFF
--- a/lib/KarmaWebpackController.js
+++ b/lib/KarmaWebpackController.js
@@ -55,7 +55,7 @@ const defaultWebpackOptions = {
       cacheGroups: {
         commons: {
           name: 'commons',
-          chunks: 'initial',
+          chunks: 'all',
           minChunks: 1,
         },
       },


### PR DESCRIPTION
In order to support dynamic imports we add all their contents to
the main bundle as well.

This PR contains a:

- [x] **bugfix**

### Motivation / Use-Case

If you use `import('./foo.js').then()` webpack will by default create different chunks.
As they are not auto served by karma we add the dynamic content to the main bundle as well.