### PR TITLE
fix(karma-webpack): disable karma watch; use webpack watch only

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ module.exports = (config) => {
 
     files: [
       // all files ending in ".test.js"
-      'test/**/*.test.js',
+      // !!! use watched: false as we use webpacks watch
+      { pattern: 'test/**/*.test.js', watched: false }
     ],
 
     preprocessors: {

--- a/lib/KarmaWebpackController.js
+++ b/lib/KarmaWebpackController.js
@@ -108,7 +108,7 @@ class KarmaWebpackController {
   constructor() {
     this.isActive = false;
     this.bundlesContent = {};
-    this.__debounce = false;
+    this.hasBeenBuiltAtLeastOnce = false;
     this.webpackOptions = defaultWebpackOptions;
   }
 
@@ -117,7 +117,7 @@ class KarmaWebpackController {
   }
 
   async bundle() {
-    if (this.isActive === false && this.__debounce === false) {
+    if (this.isActive === false && this.hasBeenBuiltAtLeastOnce === false) {
       console.log('Webpack bundling...');
       this._activePromise = this._bundle();
     }
@@ -126,7 +126,6 @@ class KarmaWebpackController {
 
   async _bundle() {
     this.isActive = true;
-    this.__debounce = true;
     this.compiler = webpack(this.webpackOptions);
     return new Promise((resolve) => {
       if (this.webpackOptions.watch === true) {
@@ -159,8 +158,8 @@ class KarmaWebpackController {
       console.warn(info.warnings);
     }
 
-    this.__debounce = setTimeout(() => (this.__debounce = false), 100);
     this.isActive = false;
+    this.hasBeenBuiltAtLeastOnce = true;
 
     console.log(stats.toString(this.webpackOptions.stats));
     resolve();

--- a/lib/karma-webpack.js
+++ b/lib/karma-webpack.js
@@ -42,7 +42,9 @@ function configToWebpackEntries(config) {
   const { preprocessors } = config;
 
   let files = [];
-  config.files.forEach((fileEntry) => {
+  config.files.forEach((fileEntry, i) => {
+    // forcefully disable karma watch as we use webpack watch only
+    config.files[i].watched = false;
     files = [...files, ...glob.sync(fileEntry.pattern)];
   });
 


### PR DESCRIPTION
This PR contains a:

- [x] **bugfix**

### Motivation / Use-Case

currently, karmas watch retriggers builds and we have a debounce to mitigate that.
However, when watching is wanted that doesn't work.

=> so disable karma watch mode
=> get rid of the debounce
=> use only webpacks watch