### PR TITLE
fix(karma-webpack):  normalize paths to be compatible with windows

### DIFF
--- a/lib/karma-webpack.js
+++ b/lib/karma-webpack.js
@@ -82,6 +82,8 @@ function preprocessorFactory(config, emitter) {
     controller.karmaEmitter = emitter;
   }
 
+  const normalize = (file) => file.replace(/\\/g, '/');
+
   const transformPath =
     config.webpack.transformPath ||
     ((filepath) => {
@@ -93,7 +95,7 @@ function preprocessorFactory(config, emitter) {
   return async function processFile(content, file, done) {
     await controller.bundle();
 
-    file.path = transformPath(file.path); // eslint-disable-line no-param-reassign
+    file.path = normalize(transformPath(file.path)); // eslint-disable-line no-param-reassign
 
     const bundleContent = controller.bundlesContent[path.parse(file.path).base];
     done(null, bundleContent);


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

Karma runner didn't work with the v5.0.0-alpha.1 of this preprocessor on Windows machines.

### Additional Info

This solves https://github.com/webpack-contrib/karma-webpack/issues/396