### PR TITLE
fix: allow for same filenames to be added

### DIFF
--- a/lib/karma-webpack.js
+++ b/lib/karma-webpack.js
@@ -37,6 +37,24 @@ function registerExtraWebpackFiles(config, _controller) {
   });
 }
 
+/**
+ * Simple hash function by bryc
+ * https://gist.github.com/iperelivskiy/4110988#gistcomment-2697447
+ */
+function hash(s) {
+  let h = 0xdeadbeef;
+  for (let i = 0; i < s.length; i++) {
+    h = Math.imul(h ^ s.charCodeAt(i), 2654435761); // eslint-disable-line no-bitwise
+  }
+  return (h ^ (h >>> 16)) >>> 0; // eslint-disable-line no-bitwise
+}
+
+function getPathKey(filePath, withExtension = false) {
+  const pathParts = path.parse(filePath);
+  const key = `${pathParts.name}.${hash(filePath)}`;
+  return withExtension ? `${key}${pathParts.ext}` : key;
+}
+
 function configToWebpackEntries(config) {
   const filteredPreprocessorsPatterns = [];
   const { preprocessors } = config;
@@ -65,7 +83,7 @@ function configToWebpackEntries(config) {
 
   const webpackEntries = {};
   filteredFiles.forEach((filePath) => {
-    webpackEntries[path.parse(filePath).name] = filePath;
+    webpackEntries[getPathKey(filePath)] = filePath;
   });
 
   return webpackEntries;
@@ -97,7 +115,8 @@ function preprocessorFactory(config, emitter) {
 
     file.path = normalize(transformPath(file.path)); // eslint-disable-line no-param-reassign
 
-    const bundleContent = controller.bundlesContent[path.parse(file.path).base];
+    const bundleContent =
+      controller.bundlesContent[getPathKey(file.path, true)];
     done(null, bundleContent);
   };
 }


### PR DESCRIPTION
This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

fixes https://github.com/webpack-contrib/karma-webpack/issues/400

### Additional Info

adds a hash to the webpack entry list so same filenames can exist.
