### PR TITLE
Fix double error logging

### DIFF
--- a/lib/KarmaWebpackController.js
+++ b/lib/KarmaWebpackController.js
@@ -150,14 +150,6 @@ class KarmaWebpackController {
       return;
     }
 
-    const info = stats.toJson();
-    if (stats.hasErrors()) {
-      console.error(info.errors);
-    }
-    if (stats.hasWarnings()) {
-      console.warn(info.warnings);
-    }
-
     this.isActive = false;
     this.hasBeenBuiltAtLeastOnce = true;
 


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

Currently when there is an error during bundling, the error is printed twice. This is very annoying, it's better to let karma handle the error logging.

### Breaking Changes

none

### Additional Info