### PR TITLE
fix(package): point to dist instead of lib

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "author": "Tobias Koppers @sokra",
   "homepage": "https://github.com/webpack-contrib/karma-webpack",
   "bugs": "https://github.com/webpack-contrib/karma-webpack/issues",
-  "main": "lib",
+  "main": "dist",
   "engines": {
     "node": ">= 8.9.0"
   },
@@ -31,7 +31,7 @@
     "defaults": "webpack-defaults"
   },
   "files": [
-    "lib"
+    "dist"
   ],
   "peerDependencies": {
     "webpack": "^4.0.0"


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

Build is now outputting to the `dist/` folder and `package.json` was targeted at `lib/`, this fixes that

Closes #415, #416
