### PR TITLE
fix(karma-webpack): don't error when webpackMiddleware config not provided

### DIFF
--- a/src/karma-webpack.js
+++ b/src/karma-webpack.js
@@ -58,7 +58,7 @@ function Plugin(
 ) {
   webpackOptions = cloneDeep(webpackOptions);
   webpackMiddlewareOptions = cloneDeep(
-    webpackMiddlewareOptions || webpackServerOptions
+    webpackMiddlewareOptions || webpackServerOptions || {}
   );
 
   const applyOptions = Array.isArray(webpackOptions)


### PR DESCRIPTION
This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

Error is thrown if no `webpackMiddleware`. You can see [here](https://github.com/Profiscience/knockout-contrib/pull/184/commits/2d1b0a8eff0e388a5814f983dd8e020cf1876ff8) the change that makes the CI pass again.

### Breaking Changes

N/A

### Additional Info

Regression introduced in 4.0.0
